### PR TITLE
Automatically use number of virtual CPUs as default for number of threads

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,4 +10,5 @@ repository = "https://github.com/torfmaster/ribzip2"
 
 [dependencies]
 structopt = "0.3.25"
+num_cpus = "1.13.0"
 libribzip2 = { path="../lib", version="0.3.1" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -80,10 +80,7 @@ fn main() {
                         num_clusters: num_tables,
                     },
                 };
-                let threads_val = match threads {
-                    None => num_cpus::get(),
-                    Some(val) => val,
-                };
+                let threads_val = threads.unwrap_or(num_cpus::get());
                 encode_stream(&mut in_file, &mut out_file, threads_val, encoding_strategy);
             }
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::path::PathBuf;
 use std::{ffi::OsString, io::BufWriter};
 use structopt::StructOpt;
+use num_cpus;
 
 #[derive(StructOpt)]
 enum Opt {
@@ -14,8 +15,8 @@ enum Opt {
     Compress {
         #[structopt(parse(from_os_str), required = true)]
         input: Vec<PathBuf>,
-        #[structopt(default_value = "1", long)]
-        threads: usize,
+        #[structopt(long)]
+        threads: Option<usize>,
         #[structopt(subcommand)]
         encoding_options: Option<EncodingOptions>,
     },
@@ -79,7 +80,11 @@ fn main() {
                         num_clusters: num_tables,
                     },
                 };
-                encode_stream(&mut in_file, &mut out_file, threads, encoding_strategy);
+                let threads_val = match threads {
+                    None => num_cpus::get(),
+                    Some(val) => val,
+                };
+                encode_stream(&mut in_file, &mut out_file, threads_val, encoding_strategy);
             }
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,10 +1,10 @@
 use libribzip2::stream::{decode_stream, encode_stream};
 use libribzip2::EncodingStrategy;
+use num_cpus;
 use std::fs::File;
 use std::path::PathBuf;
 use std::{ffi::OsString, io::BufWriter};
 use structopt::StructOpt;
-use num_cpus;
 
 #[derive(StructOpt)]
 enum Opt {


### PR DESCRIPTION
Solves https://github.com/torfmaster/ribzip2/issues/1

* Add [num_cpus](https://docs.rs/num_cpus/1.13.0/num_cpus/) crate.
* Mark `--threads` type as `Option<usize>`.
* Check whether `--threads` option has been set from command line. If not, request `num_cpus::get()`.