### PR TITLE
Improve CLI ergonomy

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,11 +1,11 @@
 use libribzip2::stream::{decode_stream, encode_stream};
 use libribzip2::EncodingStrategy;
 use num_cpus;
+use std::fmt;
 use std::fs::File;
 use std::path::PathBuf;
 use std::{ffi::OsString, io::BufWriter};
 use structopt::StructOpt;
-use std::fmt;
 
 #[derive(StructOpt)]
 enum Opt {
@@ -37,16 +37,16 @@ pub(crate) enum EncodingOptions {
 #[derive(Debug)]
 pub enum FileError {
     DuplicateError(PathBuf),
-    IoError(std::io::Error)
+    IoError(std::io::Error),
 }
 
 impl fmt::Display for FileError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FileError::DuplicateError(file_path) => 
-                write!(f, "Output file {} already exists", file_path.display()),
-            FileError::IoError(io_error) => 
-                write!(f, "{}", io_error),
+            FileError::DuplicateError(file_path) => {
+                write!(f, "Output file {} already exists", file_path.display())
+            }
+            FileError::IoError(io_error) => write!(f, "{}", io_error),
         }
     }
 }
@@ -59,15 +59,15 @@ impl From<std::io::Error> for FileError {
 
 impl std::error::Error for FileError {}
 
-fn create_file(file_path: &PathBuf) -> Result<File, FileError>{
-    if file_path.exists(){
+fn create_file(file_path: &PathBuf) -> Result<File, FileError> {
+    if file_path.exists() {
         return Err(FileError::DuplicateError(file_path.clone()));
     }
     let file = File::create(&file_path)?;
     Ok(file)
 }
 
-fn open_file(file_path: &PathBuf) -> Result<File, FileError>{
+fn open_file(file_path: &PathBuf) -> Result<File, FileError> {
     let file = File::open(&file_path)?;
     Ok(file)
 }
@@ -88,7 +88,7 @@ fn main() {
                 let out_file = create_file(&out_file_name).unwrap_or_else(|err| {
                     eprintln!("{}", err);
                     std::process::exit(1);
-                }); 
+                });
 
                 decode_stream(&mut in_file, out_file).unwrap();
             }
@@ -119,11 +119,11 @@ fn main() {
                         out_file_name.set_extension(OsString::from("bz2"));
                     }
                 }
-                
+
                 let out_file = create_file(&out_file_name).unwrap_or_else(|err| {
                     eprintln!("{}", err);
                     std::process::exit(1);
-                }); 
+                });
 
                 let mut out_file = BufWriter::new(out_file);
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -67,13 +67,18 @@ fn create_file(file_path: &PathBuf) -> Result<File, FileError>{
     Ok(file)
 }
 
+fn open_file(file_path: &PathBuf) -> Result<File, FileError>{
+    let file = File::open(&file_path)?;
+    Ok(file)
+}
+
 fn main() {
     let opt = Opt::from_args();
     match opt {
         Opt::Decompress { input } => {
             for file_name in input {
-                let mut in_file = File::open(&file_name).unwrap_or_else(|err| {
-                    eprintln!("{}", FileError::IoError(err));
+                let mut in_file = open_file(&file_name).unwrap_or_else(|err| {
+                    eprintln!("{}", err);
                     std::process::exit(1);
                 });
 
@@ -94,8 +99,8 @@ fn main() {
             encoding_options,
         } => {
             for file_name in input {
-                let mut in_file = File::open(&file_name).unwrap_or_else(|err| {
-                    eprintln!("{}", FileError::IoError(err));
+                let mut in_file = open_file(&file_name).unwrap_or_else(|err| {
+                    eprintln!("{}", err);
                     std::process::exit(1);
                 });
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -38,10 +38,21 @@ fn main() {
     match opt {
         Opt::Decompress { input } => {
             for file_name in input {
+                let mut in_file = match File::open(&file_name) {
+                    Err(why) => panic!("Couldn't open {}: {}", file_name.display(), why),
+                    Ok(file) => file,
+                };
+
                 let mut out_file_name = file_name.clone();
-                out_file_name.set_extension(OsString::from("out"));
-                let out_file = File::create(out_file_name).expect("Could not create file.");
-                let mut in_file = File::open(file_name).unwrap();
+                out_file_name.set_extension(OsString::from(""));
+                if out_file_name.exists(){
+                    panic!("Output file {} already exists", out_file_name.display());
+                }
+                let out_file = match File::create(&out_file_name) {
+                    Err(why) => panic!("Couldn't create {}: {}", out_file_name.display(), why),
+                    Ok(file) => file,
+                };
+
                 decode_stream(&mut in_file, out_file).unwrap();
             }
         }
@@ -51,6 +62,11 @@ fn main() {
             encoding_options,
         } => {
             for file_name in input {
+                let mut in_file = match File::open(&file_name) {
+                    Err(why) => panic!("Couldn't open {}: {}", file_name.display(), why),
+                    Ok(file) => file,
+                };
+
                 let mut out_file_name = file_name.clone();
                 let extension = out_file_name.extension().map(|x| {
                     let mut y = x.to_os_string();
@@ -67,9 +83,17 @@ fn main() {
                     }
                 }
 
-                let out_file = File::create(out_file_name).expect("Could not create File.");
+                if out_file_name.exists(){
+                    panic!("Output file {} already exists", out_file_name.display());
+                }
+                
+                let out_file = match File::create(&out_file_name) {
+                    Err(why) => panic!("Couldn't create {}: {}", out_file_name.display(), why),
+                    Ok(file) => file,
+                };
+
                 let mut out_file = BufWriter::new(out_file);
-                let mut in_file = File::open(file_name).unwrap();
+
                 let encoding_strategy = match encoding_options {
                     Some(EncodingOptions::Single) | None => EncodingStrategy::Single,
                     Some(EncodingOptions::KMeans {

--- a/cli/tests.sh
+++ b/cli/tests.sh
@@ -12,11 +12,13 @@ bunzip2 temp/idiot.txt.bz2
 rm temp/idiot.txt
 
 cargo run -- compress samples/pepper.txt
-cargo run -- decompress samples/pepper.txt.bz2
-rm samples/pepper.txt.bz2
-rm samples/pepper.txt.out
+mv samples/pepper.txt.bz2 temp/
+cargo run -- decompress temp/pepper.txt.bz2
+rm temp/pepper.txt.bz2
+rm temp/pepper.txt
 
 cargo run -- compress samples/idiot.txt
-cargo run -- decompress samples/idiot.txt.bz2
-rm samples/idiot.txt.bz2
-rm samples/idiot.txt.out
+mv samples/idiot.txt.bz2 temp/
+cargo run -- decompress temp/idiot.txt.bz2
+rm temp/idiot.txt.bz2
+rm temp/idiot.txt


### PR DESCRIPTION
Solves #5 

- [ ]  Compress file x.y to x.y.bz2 and decompress file x.y.bz2 to x.y
- [ ]  Check if the output files already exist and fail with an error message 
- [ ]  Handle I/O failures with error messages

