### PR TITLE
Run RLE before distributing work on threads

### DIFF
--- a/lib/src/block/block_encoder.rs
+++ b/lib/src/block/block_encoder.rs
@@ -24,7 +24,7 @@ use super::symbol_statistics::{
 
 pub(crate) fn generate_block_data(
     input: &[u8],
-    rle_data: Vec<u8>,
+    rle_data: &Vec<u8>,
     encoding_strategy: EncodingStrategy,
 ) -> (Vec<Bit>, u32) {
     let mut output = Vec::<Bit>::new();

--- a/lib/src/block/block_encoder.rs
+++ b/lib/src/block/block_encoder.rs
@@ -11,7 +11,6 @@ use crate::{
             crc32::crc32,
             huffman::{compute_huffman, HuffmanSymbol},
             mtf::mtf,
-            rle::rle,
             selectors::create_selectors,
             symbol_map::get_symbol_table,
             zle::zle_transform,
@@ -25,12 +24,12 @@ use super::symbol_statistics::{
 
 pub(crate) fn generate_block_data(
     input: &[u8],
+    rle_data: Vec<u8>,
     encoding_strategy: EncodingStrategy,
 ) -> (Vec<Bit>, u32) {
     let mut output = Vec::<Bit>::new();
     let checksum = crc32(input);
 
-    let rle_data = rle(input);
     let bwt_data = bwt(rle_data);
     let mtf_data = mtf(&bwt_data.data);
     let (zle_data, frequencies) = match encoding_strategy {

--- a/lib/src/block/bwt/bwt_internal.rs
+++ b/lib/src/block/bwt/bwt_internal.rs
@@ -27,7 +27,7 @@ fn bwt_private(string: &[u8]) -> (Vec<u8>, usize) {
 /// It uses the duval algorithm to provide a lexicographically minimal rotation of the input string
 /// and passes this to the SAIS algorithm. The rotation makes sure that the BWT is computed
 /// correctly because the rotation is lexicographically minimal.
-pub fn bwt(input: Vec<u8>) -> BwtData {
+pub fn bwt(input: &Vec<u8>) -> BwtData {
     let res = bwt_private(&input);
 
     BwtData {
@@ -48,33 +48,33 @@ mod test {
 
     #[test]
     pub fn banana() {
-        let bwt_result = bwt(b"banana".to_vec());
+        let bwt_result = bwt(&b"banana".to_vec());
         assert_eq!(bwt_result.data, b"nnbaaa".to_vec());
     }
 
     #[test]
     pub fn bananaa() {
-        let bwt_result = bwt(b"bananaa".to_vec());
+        let bwt_result = bwt(&b"bananaa".to_vec());
         assert_eq!(bwt_result.data, b"nanbaaa".to_vec());
     }
 
     #[test]
     pub fn banana2() {
-        let bwt_result = bwt(b"banana".to_vec());
+        let bwt_result = bwt(&b"banana".to_vec());
         assert_eq!(bwt_result.data, b"nnbaaa".to_vec());
         assert_eq!(bwt_result.end_of_string, 3);
     }
 
     #[test]
     pub fn longer_text() {
-        let bwt_result = bwt(b"If Peter Piper picked a peck of pickled peppers, where's the peck of pickled peppers Peter Piper picked?????".to_vec());
+        let bwt_result = bwt(&b"If Peter Piper picked a peck of pickled peppers, where's the peck of pickled peppers Peter Piper picked?????".to_vec());
         assert_eq!(24, bwt_result.end_of_string);
         assert_eq!(b"fsrrdkkeaddrrffs,esd?????     eeiiiieeeehrppkllkppttpphppPPIootwppppPPcccccckk      iipp    eeeeeeeeer'ree  ".to_vec(), bwt_result.data);
     }
 
     #[test]
     pub fn banana3() {
-        let bwt_result = bwt(b"bananaaar".to_vec());
+        let bwt_result = bwt(&b"bananaaar".to_vec());
         assert_eq!(bwt_result.data, b"nanbaraaa".to_vec());
         assert_eq!(bwt_result.end_of_string, 5);
     }

--- a/lib/src/block/mod.rs
+++ b/lib/src/block/mod.rs
@@ -6,7 +6,7 @@ mod crc32;
 mod delta;
 mod huffman;
 mod mtf;
-mod rle;
+pub mod rle;
 mod selectors;
 mod symbol_map;
 pub mod symbol_statistics;

--- a/lib/src/block/rle.rs
+++ b/lib/src/block/rle.rs
@@ -1,7 +1,11 @@
-pub fn rle(input: &[u8]) -> Vec<u8> {
+pub fn rle(
+    input: &[u8],
+    init_counter: usize,
+    init_last: Option<u8>,
+) -> (Vec<u8>, usize, Option<u8>) {
     let mut output = Vec::<u8>::new();
-    let mut counter: usize = 0;
-    let mut last = None;
+    let mut counter: usize = init_counter;
+    let mut last = init_last;
     for current in input.iter() {
         counter += 1;
         if let Some(last_byte) = last {
@@ -22,6 +26,31 @@ pub fn rle(input: &[u8]) -> Vec<u8> {
 
         last = Some(*current);
     }
+
+    (output, counter, last)
+}
+
+pub fn rle_total_size(input_len: usize, counter: usize, last: Option<u8>) -> usize {
+    let mut output_size = input_len;
+
+    if let Some(_last_byte) = last {
+        if counter >= 4 {
+            for _ in 0..4 {
+                output_size += 1;
+            }
+            output_size += 1;
+        } else {
+            for _ in 0..counter {
+                output_size += 1;
+            }
+        }
+    }
+
+    output_size
+}
+
+pub fn rle_augment(input: &[u8], counter: usize, last: Option<u8>) -> Vec<u8> {
+    let mut output = Vec::<u8>::from(input);
 
     if let Some(last_byte) = last {
         if counter >= 4 {
@@ -68,71 +97,145 @@ mod test {
     use super::*;
     #[test]
     pub fn keeps_three_byte_sequences() {
-        assert_eq!(rle(&[1, 1, 1]), vec![1, 1, 1]);
+        let rle_result = rle(&[1, 1, 1], 0, None);
+        assert_eq!(rle_result, (vec![], 3, Some(1)));
+
+        let (rle_data, rle_count, rle_last_char) = rle_result;
+        assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 3);
+
+        let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
+        assert_eq!(rle_total, vec![1, 1, 1]);
     }
 
     #[test]
     pub fn adds_overflow_to_sequence() {
-        assert_eq!(rle(&[1, 1, 1, 1]), vec![1, 1, 1, 1, 0]);
+        let rle_result = rle(&[1, 1, 1, 1], 0, None);
+        assert_eq!(rle_result, (vec![], 4, Some(1)));
+
+        let (rle_data, rle_count, rle_last_char) = rle_result;
+        assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 5);
+
+        let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
+        assert_eq!(rle_total, vec![1, 1, 1, 1, 0]);
     }
 
     #[test]
     pub fn larger_numbers() {
-        assert_eq!(rle(&[1, 1, 1, 1, 1]), vec![1, 1, 1, 1, 1]);
+        let rle_result = rle(&[1, 1, 1, 1, 1], 0, None);
+        assert_eq!(rle_result, (vec![], 5, Some(1)));
+
+        let (rle_data, rle_count, rle_last_char) = rle_result;
+        assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 5);
+
+        let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
+        assert_eq!(rle_total, vec![1, 1, 1, 1, 1]);
     }
 
     #[test]
     pub fn mixed_sequences() {
-        assert_eq!(rle(&[1, 1, 1, 1, 2, 2, 2]), vec![1, 1, 1, 1, 0, 2, 2, 2]);
+        let rle_result = rle(&[1, 1, 1, 1, 2, 2, 2], 0, None);
+        assert_eq!(rle_result, (vec![1, 1, 1, 1, 0], 3, Some(2)));
+
+        let (rle_data, rle_count, rle_last_char) = rle_result;
+        assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 8);
+
+        let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
+        assert_eq!(rle_total, vec![1, 1, 1, 1, 0, 2, 2, 2]);
     }
 
     #[test]
     pub fn mixed_sequences_with_length() {
-        assert_eq!(
-            rle(&[1, 1, 1, 1, 1, 2, 2, 2, 2, 2]),
-            vec![1, 1, 1, 1, 1, 2, 2, 2, 2, 1]
-        );
+        let rle_result = rle(&[1, 1, 1, 1, 1, 2, 2, 2, 2, 2], 0, None);
+        assert_eq!(rle_result, (vec![1, 1, 1, 1, 1], 5, Some(2)));
+
+        let (rle_data, rle_count, rle_last_char) = rle_result;
+        assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 10);
+
+        let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
+        assert_eq!(rle_total, vec![1, 1, 1, 1, 1, 2, 2, 2, 2, 1]);
     }
 
     #[test]
     pub fn mixed_sequences_with_and_without_length() {
-        assert_eq!(rle(&[1, 1, 1, 2, 2, 2, 2, 2]), vec![1, 1, 1, 2, 2, 2, 2, 1]);
+        let rle_result = rle(&[1, 1, 1, 2, 2, 2, 2, 2], 0, None);
+        assert_eq!(rle_result, (vec![1, 1, 1], 5, Some(2)));
+
+        let (rle_data, rle_count, rle_last_char) = rle_result;
+        assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 8);
+
+        let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
+        assert_eq!(rle_total, vec![1, 1, 1, 2, 2, 2, 2, 1]);
     }
 
     #[test]
     pub fn mixed_sequences_with_and_without_length_2() {
-        assert_eq!(rle(&[1, 1, 1, 1, 2, 2, 2]), vec![1, 1, 1, 1, 0, 2, 2, 2]);
+        let rle_result = rle(&[1, 1, 1, 1, 2, 2, 2], 0, None);
+        assert_eq!(rle_result, (vec![1, 1, 1, 1, 0], 3, Some(2)));
+
+        let (rle_data, rle_count, rle_last_char) = rle_result;
+        assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 8);
+
+        let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
+        assert_eq!(rle_total, vec![1, 1, 1, 1, 0, 2, 2, 2]);
     }
 
     #[test]
     pub fn even_longer_sequences() {
-        assert_eq!(
-            rle(&[1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3]),
-            vec![1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3]
-        );
+        let rle_result = rle(&[1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3], 0, None);
+        assert_eq!(rle_result, (vec![1, 1, 1, 1, 2, 2, 2, 2, 2, 2], 3, Some(3)));
+
+        let (rle_data, rle_count, rle_last_char) = rle_result;
+        assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 13);
+
+        let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
+        assert_eq!(rle_total, vec![1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3]);
     }
 
     #[test]
     pub fn max_block_length() {
-        assert_eq!(
-            rle(&std::iter::repeat(3).take(255).collect::<Vec<u8>>()),
-            vec![3, 3, 3, 3, 251]
+        let rle_result = rle(
+            &std::iter::repeat(3).take(255).collect::<Vec<u8>>(),
+            0,
+            None,
         );
+        assert_eq!(rle_result, (vec![], 255, Some(3)));
+
+        let (rle_data, rle_count, rle_last_char) = rle_result;
+        assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 5);
+
+        let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
+        assert_eq!(rle_total, vec![3, 3, 3, 3, 251]);
     }
 
     #[test]
     pub fn more_than_max_block_length() {
-        assert_eq!(
-            rle(&std::iter::repeat(3).take(256).collect::<Vec<u8>>()),
-            vec![3, 3, 3, 3, 251, 3]
+        let rle_result = rle(
+            &std::iter::repeat(3).take(256).collect::<Vec<u8>>(),
+            0,
+            None,
         );
+        assert_eq!(rle_result, (vec![3, 3, 3, 3, 251], 1, Some(3)));
+
+        let (rle_data, rle_count, rle_last_char) = rle_result;
+        assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 6);
+
+        let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
+        assert_eq!(rle_total, vec![3, 3, 3, 3, 251, 3]);
     }
     #[test]
     pub fn twice_max_block_length() {
-        assert_eq!(
-            rle(&std::iter::repeat(3).take(510).collect::<Vec<u8>>()),
-            vec![3, 3, 3, 3, 251, 3, 3, 3, 3, 251]
+        let rle_result = rle(
+            &std::iter::repeat(3).take(510).collect::<Vec<u8>>(),
+            0,
+            None,
         );
+        assert_eq!(rle_result, (vec![3, 3, 3, 3, 251], 255, Some(3)));
+
+        let (rle_data, rle_count, rle_last_char) = rle_result;
+        assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 10);
+
+        let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
+        assert_eq!(rle_total, vec![3, 3, 3, 3, 251, 3, 3, 3, 3, 251]);
     }
 
     #[test]

--- a/lib/src/block/rle.rs
+++ b/lib/src/block/rle.rs
@@ -1,8 +1,10 @@
-pub fn rle(
-    input: &[u8],
-    init_counter: usize,
-    init_last: Option<u8>,
-) -> (Vec<u8>, usize, Option<u8>) {
+pub struct RleResult {
+    pub data: Vec<u8>,
+    pub counter: usize,
+    pub last_byte: Option<u8>,
+}
+
+pub fn rle(input: &[u8], init_counter: usize, init_last: Option<u8>) -> RleResult {
     let mut output = Vec::<u8>::new();
     let mut counter: usize = init_counter;
     let mut last = init_last;
@@ -27,7 +29,11 @@ pub fn rle(
         last = Some(*current);
     }
 
-    (output, counter, last)
+    RleResult {
+        data: output,
+        counter,
+        last_byte: last,
+    }
 }
 
 pub fn rle_total_size(input_len: usize, counter: usize, last: Option<u8>) -> usize {
@@ -35,14 +41,9 @@ pub fn rle_total_size(input_len: usize, counter: usize, last: Option<u8>) -> usi
 
     if let Some(_last_byte) = last {
         if counter >= 4 {
-            for _ in 0..4 {
-                output_size += 1;
-            }
-            output_size += 1;
+            output_size += 5;
         } else {
-            for _ in 0..counter {
-                output_size += 1;
-            }
+            output_size += counter;
         }
     }
 
@@ -98,9 +99,14 @@ mod test {
     #[test]
     pub fn keeps_three_byte_sequences() {
         let rle_result = rle(&[1, 1, 1], 0, None);
-        assert_eq!(rle_result, (vec![], 3, Some(1)));
 
-        let (rle_data, rle_count, rle_last_char) = rle_result;
+        let rle_data = rle_result.data;
+        let rle_count = rle_result.counter;
+        let rle_last_char = rle_result.last_byte;
+        assert_eq!(rle_data, vec![]);
+        assert_eq!(rle_count, 3);
+        assert_eq!(rle_last_char, Some(1));
+
         assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 3);
 
         let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
@@ -110,9 +116,14 @@ mod test {
     #[test]
     pub fn adds_overflow_to_sequence() {
         let rle_result = rle(&[1, 1, 1, 1], 0, None);
-        assert_eq!(rle_result, (vec![], 4, Some(1)));
 
-        let (rle_data, rle_count, rle_last_char) = rle_result;
+        let rle_data = rle_result.data;
+        let rle_count = rle_result.counter;
+        let rle_last_char = rle_result.last_byte;
+        assert_eq!(rle_data, vec![]);
+        assert_eq!(rle_count, 4);
+        assert_eq!(rle_last_char, Some(1));
+
         assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 5);
 
         let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
@@ -122,9 +133,14 @@ mod test {
     #[test]
     pub fn larger_numbers() {
         let rle_result = rle(&[1, 1, 1, 1, 1], 0, None);
-        assert_eq!(rle_result, (vec![], 5, Some(1)));
 
-        let (rle_data, rle_count, rle_last_char) = rle_result;
+        let rle_data = rle_result.data;
+        let rle_count = rle_result.counter;
+        let rle_last_char = rle_result.last_byte;
+        assert_eq!(rle_data, vec![]);
+        assert_eq!(rle_count, 5);
+        assert_eq!(rle_last_char, Some(1));
+
         assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 5);
 
         let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
@@ -134,9 +150,14 @@ mod test {
     #[test]
     pub fn mixed_sequences() {
         let rle_result = rle(&[1, 1, 1, 1, 2, 2, 2], 0, None);
-        assert_eq!(rle_result, (vec![1, 1, 1, 1, 0], 3, Some(2)));
 
-        let (rle_data, rle_count, rle_last_char) = rle_result;
+        let rle_data = rle_result.data;
+        let rle_count = rle_result.counter;
+        let rle_last_char = rle_result.last_byte;
+        assert_eq!(rle_data, vec![1, 1, 1, 1, 0]);
+        assert_eq!(rle_count, 3);
+        assert_eq!(rle_last_char, Some(2));
+
         assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 8);
 
         let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
@@ -146,9 +167,14 @@ mod test {
     #[test]
     pub fn mixed_sequences_with_length() {
         let rle_result = rle(&[1, 1, 1, 1, 1, 2, 2, 2, 2, 2], 0, None);
-        assert_eq!(rle_result, (vec![1, 1, 1, 1, 1], 5, Some(2)));
 
-        let (rle_data, rle_count, rle_last_char) = rle_result;
+        let rle_data = rle_result.data;
+        let rle_count = rle_result.counter;
+        let rle_last_char = rle_result.last_byte;
+        assert_eq!(rle_data, vec![1, 1, 1, 1, 1]);
+        assert_eq!(rle_count, 5);
+        assert_eq!(rle_last_char, Some(2));
+
         assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 10);
 
         let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
@@ -158,9 +184,14 @@ mod test {
     #[test]
     pub fn mixed_sequences_with_and_without_length() {
         let rle_result = rle(&[1, 1, 1, 2, 2, 2, 2, 2], 0, None);
-        assert_eq!(rle_result, (vec![1, 1, 1], 5, Some(2)));
 
-        let (rle_data, rle_count, rle_last_char) = rle_result;
+        let rle_data = rle_result.data;
+        let rle_count = rle_result.counter;
+        let rle_last_char = rle_result.last_byte;
+        assert_eq!(rle_data, vec![1, 1, 1]);
+        assert_eq!(rle_count, 5);
+        assert_eq!(rle_last_char, Some(2));
+
         assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 8);
 
         let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
@@ -170,9 +201,14 @@ mod test {
     #[test]
     pub fn mixed_sequences_with_and_without_length_2() {
         let rle_result = rle(&[1, 1, 1, 1, 2, 2, 2], 0, None);
-        assert_eq!(rle_result, (vec![1, 1, 1, 1, 0], 3, Some(2)));
 
-        let (rle_data, rle_count, rle_last_char) = rle_result;
+        let rle_data = rle_result.data;
+        let rle_count = rle_result.counter;
+        let rle_last_char = rle_result.last_byte;
+        assert_eq!(rle_data, vec![1, 1, 1, 1, 0]);
+        assert_eq!(rle_count, 3);
+        assert_eq!(rle_last_char, Some(2));
+
         assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 8);
 
         let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
@@ -182,9 +218,14 @@ mod test {
     #[test]
     pub fn even_longer_sequences() {
         let rle_result = rle(&[1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3], 0, None);
-        assert_eq!(rle_result, (vec![1, 1, 1, 1, 2, 2, 2, 2, 2, 2], 3, Some(3)));
 
-        let (rle_data, rle_count, rle_last_char) = rle_result;
+        let rle_data = rle_result.data;
+        let rle_count = rle_result.counter;
+        let rle_last_char = rle_result.last_byte;
+        assert_eq!(rle_data, vec![1, 1, 1, 1, 2, 2, 2, 2, 2, 2]);
+        assert_eq!(rle_count, 3);
+        assert_eq!(rle_last_char, Some(3));
+
         assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 13);
 
         let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
@@ -198,9 +239,14 @@ mod test {
             0,
             None,
         );
-        assert_eq!(rle_result, (vec![], 255, Some(3)));
 
-        let (rle_data, rle_count, rle_last_char) = rle_result;
+        let rle_data = rle_result.data;
+        let rle_count = rle_result.counter;
+        let rle_last_char = rle_result.last_byte;
+        assert_eq!(rle_data, vec![]);
+        assert_eq!(rle_count, 255);
+        assert_eq!(rle_last_char, Some(3));
+
         assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 5);
 
         let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
@@ -214,9 +260,14 @@ mod test {
             0,
             None,
         );
-        assert_eq!(rle_result, (vec![3, 3, 3, 3, 251], 1, Some(3)));
 
-        let (rle_data, rle_count, rle_last_char) = rle_result;
+        let rle_data = rle_result.data;
+        let rle_count = rle_result.counter;
+        let rle_last_char = rle_result.last_byte;
+        assert_eq!(rle_data, vec![3, 3, 3, 3, 251]);
+        assert_eq!(rle_count, 1);
+        assert_eq!(rle_last_char, Some(3));
+
         assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 6);
 
         let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);
@@ -229,9 +280,14 @@ mod test {
             0,
             None,
         );
-        assert_eq!(rle_result, (vec![3, 3, 3, 3, 251], 255, Some(3)));
 
-        let (rle_data, rle_count, rle_last_char) = rle_result;
+        let rle_data = rle_result.data;
+        let rle_count = rle_result.counter;
+        let rle_last_char = rle_result.last_byte;
+        assert_eq!(rle_data, vec![3, 3, 3, 3, 251]);
+        assert_eq!(rle_count, 255);
+        assert_eq!(rle_last_char, Some(3));
+
         assert_eq!(rle_total_size(rle_data.len(), rle_count, rle_last_char), 10);
 
         let rle_total = rle_augment(&rle_data, rle_count, rle_last_char);

--- a/lib/src/stream/mod.rs
+++ b/lib/src/stream/mod.rs
@@ -141,7 +141,9 @@ pub fn encode_stream(
                     break;
                 }
                 let rle_result = rle(&buf_current, rle_count, rle_last_char);
-                let (mut rle_next, rle_next_count, rle_next_char) = rle_result;
+                let mut rle_next = rle_result.data;
+                let rle_next_count = rle_result.counter;
+                let rle_next_char = rle_result.last_byte;
 
                 let next_data_len = rle_data.len() + rle_next.len();
                 rle_total_count = rle_total_size(next_data_len, rle_next_count, rle_next_char);

--- a/lib/src/stream/mod.rs
+++ b/lib/src/stream/mod.rs
@@ -69,7 +69,7 @@ impl WorkerThread {
                 while let Ok(work) = receive_work.recv() {
                     let (buffer, rle_data) = work;
                     send_result
-                        .send(generate_block_data(&buffer, rle_data, encoding_strategy))
+                        .send(generate_block_data(&buffer, &rle_data, encoding_strategy))
                         .unwrap();
                 }
             })
@@ -146,13 +146,10 @@ pub fn encode_stream(
                 let next_data_len = rle_data.len() + rle_next.len();
                 rle_total_count = rle_total_size(next_data_len, rle_next_count, rle_next_char);
 
-                // Avoid exceeding the limit.
-                if rle_total_count <= RLE_LIMIT {
-                    rle_data.append(&mut rle_next);
-                    buf.append(&mut buf_current);
-                    rle_count = rle_next_count;
-                    rle_last_char = rle_next_char;
-                }
+                rle_data.append(&mut rle_next);
+                buf.append(&mut buf_current);
+                rle_count = rle_next_count;
+                rle_last_char = rle_next_char;
             }
 
             if buf.len() == 0 {


### PR DESCRIPTION
Solves https://github.com/torfmaster/ribzip2/issues/4

* Calculate RLE data in the main thread
* Send calculated data to `generate_block_data`
* Move `rle::rle` from `block_encoder` to `stream`