### PR TITLE
Change libzip2 to libbzip2 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and the respective help options of `compress` and `decompress`, e.g. `ribzip2 co
 
  * ergonomic library crate
  * drop-in replacement for the bzip2 crate
- * drop-in replacement for C libzip2
+ * drop-in replacement for C libbzip2
  * drop-in replacement for the C bzip2/bunzip2 binary
 
 ## Publishing


### PR DESCRIPTION
I am not an expert - but I expect the lib is `libbzip2` and not `libzip2` - a quick google seems to suggest I am right :)
Feel free to merge - or to discard!