### PR TITLE
Compute crc32 before sending work to threads

### DIFF
--- a/lib/src/block/block_encoder.rs
+++ b/lib/src/block/block_encoder.rs
@@ -8,7 +8,6 @@ use crate::{
         block::{
             bwt::bwt,
             code_table::encode_code_table,
-            crc32::crc32,
             huffman::{compute_huffman, HuffmanSymbol},
             mtf::mtf,
             selectors::create_selectors,
@@ -23,12 +22,11 @@ use super::symbol_statistics::{
 };
 
 pub(crate) fn generate_block_data(
-    input: &[u8],
+    checksum: u32,
     rle_data: &Vec<u8>,
     encoding_strategy: EncodingStrategy,
 ) -> (Vec<Bit>, u32) {
     let mut output = Vec::<Bit>::new();
-    let checksum = crc32(input);
 
     let bwt_data = bwt(rle_data);
     let mtf_data = mtf(&bwt_data.data);

--- a/lib/src/block/mod.rs
+++ b/lib/src/block/mod.rs
@@ -2,7 +2,7 @@ pub mod block_decoder;
 pub mod block_encoder;
 mod bwt;
 mod code_table;
-mod crc32;
+pub mod crc32;
 mod delta;
 mod huffman;
 mod mtf;


### PR DESCRIPTION
Solves https://github.com/torfmaster/ribzip2/issues/20

* Move crc32 checksum computation outside of `generate_block_data`