### PR TITLE
Draft: add read implementation instead of function

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,4 @@
-use libribzip2::stream::{decode_stream, encode_stream};
+use libribzip2::stream::{decode_stream, Encoder};
 use libribzip2::EncodingStrategy;
 use num_cpus;
 use std::fmt;
@@ -119,7 +119,8 @@ fn try_main(opt: Opt) -> Result<(), FileError> {
                     },
                 };
                 let threads_val = threads.unwrap_or(num_cpus::get());
-                encode_stream(&mut in_file, &mut out_file, threads_val, encoding_strategy);
+                let mut encoder = Encoder::new(in_file, encoding_strategy, threads_val);
+                std::io::copy(&mut encoder, &mut out_file).unwrap();
             }
         }
     }

--- a/lib/src/stream/mod.rs
+++ b/lib/src/stream/mod.rs
@@ -26,9 +26,18 @@ use super::block::symbol_statistics::EncodingStrategy;
 
 /// Encoder to bzip2 encode a stream.
 /// ```rust
+/// use libribzip2::EncodingStrategy;
+/// use libribzip2::stream::Encoder;
+/// use std::io::Cursor;
+///
 /// let num_threads = 4;
-/// let mut encoder = Encoder::new(in_file, encoding_strategy, num_threads);
-/// std::io::copy(&mut encoder, &mut out_file)?;
+/// let encoding_strategy = EncodingStrategy::Single;
+///
+/// let reader = Cursor::new(vec![1, 2, 3, 4]);
+/// let mut writer = vec![];
+///
+/// let mut encoder = Encoder::new(reader, encoding_strategy, num_threads);
+/// std::io::copy(&mut encoder, &mut writer).unwrap();
 /// ```
 pub struct Encoder<T: Read> {
     reader: T,

--- a/lib/src/stream/mod.rs
+++ b/lib/src/stream/mod.rs
@@ -261,6 +261,19 @@ fn what_next(mut bit_reader: impl BitReader) -> Result<BlockType, ()> {
     }
 }
 
+/// Encode a stream into a writer. Takes a reader and a writer (i.e. two instances of [std::fs::File]).
+/// The number of threads and the encoding strategy can be specified.
+#[deprecated]
+pub fn encode_stream(
+    read: impl Read,
+    mut writer: impl Write,
+    num_threads: usize,
+    encoding_strategy: EncodingStrategy,
+) {
+    let mut encoder = Encoder::new(read, encoding_strategy, num_threads);
+    std::io::copy(&mut encoder, &mut writer).unwrap();
+}
+
 /// Decode a stream into a writer. Takes a reader and a writer (i.e. two instances of [std::fs::File])
 pub fn decode_stream(mut reader: impl Read, mut writer: impl Write) -> Result<(), ()> {
     let mut bit_reader = BitReaderImpl::from_reader(&mut reader);


### PR DESCRIPTION
An attempt to solve #18. It seems to be a feasible goal. Further steps

- [ ] improve docs and make the `Read` implementation the preferred way
- [ ] also apply the concepts also for decompression. Open question: how to deal with domain specific errors? Logging? Create extra recovering/analysis related methods for decompression?
- [ ] attempt `Write` base trait implementations as well to get full compatibility

Also fyi @caglaryucekaya.